### PR TITLE
Agent review and cleanup

### DIFF
--- a/src/main/java/com/instrumentalapp/Agent.java
+++ b/src/main/java/com/instrumentalapp/Agent.java
@@ -53,7 +53,7 @@ public class Agent {
 	}
 
 	public int getPending() {
-		if (agentOptions.getEnabled()) {
+		if (!agentOptions.getEnabled()) {
 			return 0;
 		} else {
 			return connection.messages.size();

--- a/src/main/java/com/instrumentalapp/Agent.java
+++ b/src/main/java/com/instrumentalapp/Agent.java
@@ -103,7 +103,7 @@ public class Agent {
 		try {
 			runnable.run();
 		} finally {
-			gauge(metricName, (System.currentTimeMillis() - start) / 1000 * multiplier.floatValue());
+			gauge(metricName, (System.currentTimeMillis() - start) / 1000f * multiplier.floatValue());
 		}
 	}
 
@@ -124,7 +124,7 @@ public class Agent {
 		try {
 			val = callable.call();
 		} finally {
-			gauge(metricName, (System.currentTimeMillis() - start) / 1000 * multiplier.floatValue());
+			gauge(metricName, (System.currentTimeMillis() - start) / 1000f * multiplier.floatValue());
 		}
 
 		if (thrown != null) {
@@ -155,7 +155,7 @@ public class Agent {
 				} catch (Exception ex) {
 					thrown = ex;
 				} finally {
-					gauge(metricName, (System.currentTimeMillis() - start) / 1000 * multiplier.floatValue());
+					gauge(metricName, (System.currentTimeMillis() - start) / 1000f * multiplier.floatValue());
 				}
 
 				if (thrown != null) {
@@ -185,7 +185,7 @@ public class Agent {
 				try {
 					r.run();
 				} finally {
-					gauge(metricName, (System.currentTimeMillis() - start) / 1000 * multiplier.floatValue());
+					gauge(metricName, (System.currentTimeMillis() - start) / 1000f * multiplier.floatValue());
 				}
 			}
 		}, result);

--- a/src/test/java/com/instrumentalapp/AgentTest.java
+++ b/src/test/java/com/instrumentalapp/AgentTest.java
@@ -4,6 +4,7 @@ import org.junit.*;
 import java.io.*;
 import java.util.Scanner;
 import java.util.Random;
+import java.util.concurrent.Callable;
 
 public class AgentTest {
 
@@ -44,6 +45,16 @@ public class AgentTest {
             agent.gauge("test.gauge", val);
         }
         // TODO: Assert the number of metrics sent.
+    }
+
+    @Test
+    public void timeTest() throws Exception {
+        Assert.assertEquals("test string", agent.time("test.time", new Callable() {
+                    @Override
+                    public String call() {
+                        return "test string";
+                    }
+                }));
     }
 
     @Test

--- a/src/test/java/com/instrumentalapp/AgentTest.java
+++ b/src/test/java/com/instrumentalapp/AgentTest.java
@@ -51,7 +51,19 @@ public class AgentTest {
     public void timeTest() throws Exception {
         Assert.assertEquals("test string", agent.time("test.time", new Callable() {
                     @Override
-                    public String call() {
+                    public String call() throws Exception{
+                        Thread.sleep(100);
+                        return "test string";
+                    }
+                }));
+    }
+
+    @Test
+    public void timeMsTest() throws Exception {
+        Assert.assertEquals("test string", agent.timeMs("test.timeMs", new Callable() {
+                    @Override
+                    public String call() throws Exception{
+                        Thread.sleep(100);
                         return "test string";
                     }
                 }));

--- a/src/test/java/com/instrumentalapp/AgentTest.java
+++ b/src/test/java/com/instrumentalapp/AgentTest.java
@@ -11,9 +11,10 @@ public class AgentTest {
 
     private static Random r = new Random();
     private static String apiKey;
+    private Agent agent;
 
-    @Before
-    public void setUp() throws Exception {
+    @BeforeClass
+    public static void setUp() throws Exception {
         try {
             Scanner scanner = new Scanner( new File("test_key") );
             apiKey = scanner.useDelimiter("\\A").next();
@@ -22,60 +23,46 @@ public class AgentTest {
         }
     }
 
-    @Test
-    public void gaugeTest() {
-        Agent agent = new Agent(new AgentOptions().setApiKey(apiKey));
+    @Before
+    public void initializeAgent() {
+        agent = new Agent(new AgentOptions().setApiKey(apiKey));
+    }
 
-        for (int i = 1; i < 20; i++) {
-            float val = r.nextFloat() * 100;
-            agent.gauge("test.gauge", val);
-        }
-
+    @After
+    public void waitForAgentFlush() {
         while (agent.getPending() > 0) {
             try {
                 Thread.sleep(100);
             } catch (InterruptedException ie) {}
         }
+    }
 
+    @Test
+    public void gaugeTest() {
+        for (int i = 1; i < 20; i++) {
+            float val = r.nextFloat() * 100;
+            agent.gauge("test.gauge", val);
+        }
         // TODO: Assert the number of metrics sent.
     }
 
     @Test
     public void incrementTest() {
-        Agent agent = new Agent(new AgentOptions().setApiKey(apiKey));
-
         for (int i = 1; i < 20; i++) {
             agent.increment("test.increment");
         }
-
-        while (agent.getPending() > 0) {
-            try {
-                Thread.sleep(100);
-            } catch (InterruptedException ie) {}
-        }
-
         // TODO: Assert the number of metrics sent.
     }
 
     @Test
-    public void noticeTest() {
-        Agent agent = new Agent(new AgentOptions().setApiKey(apiKey));
-
-        agent.notice("test.execution", (System.currentTimeMillis() - start) / 1000, start);
-
-        while (agent.getPending() > 0) {
-            try {
-                Thread.sleep(100);
-            } catch (InterruptedException ie) {}
-        }
+    public void noticeTest() throws Exception {
+        agent.notice("This is a 2 minutes notice from Java", start - 120000, 120000);
     }
 
     @Test
     public void nonblockingTest() {
-        Agent agent = new Agent(new AgentOptions().setApiKey(apiKey));
-
         for (int i = 1; i < (Connection.MAX_QUEUE_SIZE + 1); i++) {
-            agent.increment("test.increment");
+            agent.increment("test.increment.nonblocking");
         }
 
         Assert.assertFalse("Queue buffer overrun when it shouldn't", agent.isQueueOverflowing());

--- a/src/test/java/com/instrumentalapp/ConnectionTest.java
+++ b/src/test/java/com/instrumentalapp/ConnectionTest.java
@@ -6,17 +6,23 @@ import java.util.Scanner;
 
 public class ConnectionTest {
 
-	private static String apiKey;
+  private static String apiKey;
+  private Connection connection;
 
-	@Before
-	public void setUp() throws Exception {
-	    try {
-	        Scanner scanner = new Scanner( new File("test_key") );
-	        apiKey = scanner.useDelimiter("\\A").next();
-	    } catch(FileNotFoundException e) {
-	        Assert.assertTrue("Please put the test project key into file 'test_key' in the project root", false);
-	    }
-	}
+  @BeforeClass
+  public static void setUp() throws Exception {
+    try {
+        Scanner scanner = new Scanner( new File("test_key") );
+        apiKey = scanner.useDelimiter("\\A").next();
+    } catch(FileNotFoundException e) {
+        Assert.assertTrue("Please put the test project key into file 'test_key' in the project root", false);
+    }
+  }
+
+  @Before
+  public void initializeConnection() {
+      connection = new Connection(new AgentOptions().setApiKey(apiKey));
+  }
 
 	@Test
 	public void connectionLazyStart() {


### PR DESCRIPTION
Fixed an issue with `Agent` where an enabled agent would always have returned an empty queue when asked how many messages were pending.

Moved a lot of test boilerplate into `setup/teardown`.

Added a test for `time()` and its values.

Added a test for time that uses `Callable<V>` to execute a task and get a value back.

Make it so that `time()` and `timeMs()` work with sub-second timings
